### PR TITLE
Remove defunct g965-02 from reboot targets

### DIFF
--- a/build_specification.xml
+++ b/build_specification.xml
@@ -45,7 +45,7 @@
     </project>
 
     <project name="reboot-slaves">
-      <prerequisite name="reboot-slave" hardware="g45-01,g965-01,g965-02,ilk-01,ilk-02,ilk-03,ivbgt2-01,ivbgt2-02,snbgt1-01,snbgt1-02,snbgt2-01,snbgt2-02,bdwgt2-01,bdwgt2-02,hswgt1-01,hswgt1-02,ivbgt1-01,ivbgt1-02"/>
+      <prerequisite name="reboot-slave" hardware="g45-01,g965-01,ilk-01,ilk-02,ilk-03,ivbgt2-01,ivbgt2-02,snbgt1-01,snbgt1-02,snbgt2-01,snbgt2-02,bdwgt2-01,bdwgt2-02,hswgt1-01,hswgt1-02,ivbgt1-01,ivbgt1-02"/>
     </project>
 
     <project name="reboot-slave"/>


### PR DESCRIPTION
Since this machine has been down for some time a large number of jobs
that cannot complete are being generated.