### PR TITLE
debian_installer: Change configuration to use salt

### DIFF
--- a/debian_installer/finalize.sh
+++ b/debian_installer/finalize.sh
@@ -1,162 +1,27 @@
-#!/bin/bash
-# Run a few commands in the target system after the install
+mkdir -p /etc/salt/minion.d/
 
-# Enables render-nodes as needed by gbm and disables the software_cmd_parser
-sed -i -e 's!GRUB_CMDLINE_LINUX=""!GRUB_CMDLINE_LINUX="drm.rnodes=1 i915.enable_cmd_parser=0"!g' /etc/default/grub
+# Add the master to point at to the machine
+cat > /etc/salt/minion.d/master.conf << EOF
+master: 192.168.1.1
+master_finger: ba:42:e5:d8:e6:3f:ec:ff:a4:7b:c3:cd:24:74:2a:8b
+EOF
 
-# Replace wheezy with sid in the sources.list file, then updates to sid, the
-# does a dist-upgrade to sid in a fully non-interactive way
-cat > /etc/apt/sources.list << EOF
+echo 'startup_states: highstate' > /etc/salt/minion.d/startup.conf
+
+# Update to Testing
+cat > /etc/apt/sources.list <<EOF
 deb http://linux-ftp.jf.intel.com/pub/mirrors/debian/ testing main
 deb-src http://linux-ftp.jf.intel.com/pub/mirrors/debian/ testing main
 EOF
 
 apt-get update -y
-# Do a dist-upgrade. for some reason this doesn't complete so force it to
-# do a dist-upgrade multiple times
 for _ in `seq 3`; do
-	DEBIAN_FRONTEND=noninteractive \
-	APT_LISTCHANGES_FRONTEND=mail \
-		apt-get -o Dpkg::Options::="--force-confdef" \
-		--force-yes -fuy dist-upgrade
+    DEBIAN_FRONTEND=noninteractive \
+    APT_LISTCHANGES_FRONTEND=mail \
+        apt-get -o Dpkg::Options::="--force-confdef" \
+        --force-yes -fuy dist-upgrade
 done
-
-# systemd-sysv requires '--force-yes' to be installed without supervision, it
-# cannot be isntalled in package select. It also must be installed after the sid
-# update has happened since it doesn't seem possible to automate in wheezy
-apt-get install -y --force-yes systemd-sysv
-
-# install additional packages. Many of these are i386 dev packages that cannot
-# be co-installed with the amd64 versions in debian stale but can on sid
-apt-get install -y --force-yes \
-	avahi-daemon \
-	libdrm2 libdrm2:i386 \
-    emacs \
-	freeglut3 freeglut3:i386 \
-	gcc-4.9-base gcc-4.9-base:i386 \
-	libc6 libc6:i386 \
-	libc6-dev libc6-dev:i386 \
-    libcaca0 libcaca0:i386 \
-	libegl1-mesa libegl1-mesa:i386 \
-	libegl1-mesa-dev \
-	libelf-dev libelf-dev:i386 \
-	libexpat1-dev libexpat1-dev:i386 \
-	libffi-dev libffi-dev:i386 \
-	libffi6 libffi6:i386 \
-	libffi-dev \
-	libgbm1 libgbm1:i386 \
-	libgbm-dev \
-	libgcc1 libgcc1:i386 \
-	libgl1-mesa-dev \
-	libgl1-mesa-dri libgl1-mesa-dri:i386 \
-	libgl1-mesa-glx libgl1-mesa-glx:i386 \
-	libegl1-mesa libegl1-mesa:i386 \
-	libegl1-mesa-drivers libegl1-mesa-drivers:i386 \
-	libglapi-mesa \
-	libglu1-mesa libglu1-mesa:i386 \
-	libglu1-mesa-dev \
-	libllvm3.4 libllvm3.4:i386 \
-	libpciaccess-dev libpciaccess-dev:i386 \
-	libpciaccess0 libpciaccess0:i386 \
-    libpng12-dev \
-	libpthread-stubs0-dev \
-	libtinfo-dev libtinfo-dev:i386 \
-	libudev-dev libudev-dev:i386 \
-	libvdpau-dev libvdpau-dev:i386 \
-	libx11-dev libx11-dev:i386 \
-	libx11-xcb-dev libx11-xcb-dev:i386 \
-	libxcb-dri2-0-dev libxcb-dri2-0-dev:i386 \
-	libxcb-dri3-dev libxcb-dri3-dev:i386 \
-	libxcb-glx0-dev libxcb-glx0-dev:i386 \
-	libxcb-present-dev libxcb-present-dev:i386 \
-	libxcb-randr0-dev libxcb-randr0-dev:i386 \
-	libxcb-sync-dev libxcb-sync-dev:i386 \
-	libxcb-xfixes0-dev libxcb-xfixes0-dev:i386 \
-	libxdamage-dev libxdamage-dev:i386 \
-	libxext-dev libxext-dev:i386 \
-	libxfixes-dev libxfixes-dev:i386 \
-	libxrender1 libxrender1:i386 \
-	libxshmfence-dev libxshmfence-dev:i386 \
-	libxxf86vm-dev libxxf86vm-dev:i386 \
-	linux-libc-dev linux-libc-dev:i386 \
-    libssl-dev libssl-dev:i386 \
-    scons \
-	x11proto-dri2-dev \
-	x11proto-dri3-dev \
-	x11proto-gl-dev \
-	x11proto-present-dev \
-    xutils-dev \
-    valgrind \
-
-# Remove any unused applications and libs
-apt-get autoremove -y --force-yes
-
-# Disable the pc-spkr module
-echo 'blacklist pcspkr\nblacklist snd_pc' > /etc/modprobe.d/pcspkr.conf
 
 # Enable and disable some services
-systemctl enable ntp avahi-daemon
+systemctl enable avahi-daemon salt-minion
 systemctl disable saned hdparm
-
-# Create a wrapper for git that uses tsocks to get through the proxy
-[[ -z '/usr/local/bin' ]] && mkdir -p /usr/local/bin
-cat > /usr/local/bin/git <<EOF
-#!/bin/bash
-
-/usr/bin/tsocks /usr/bin/git \$*
-EOF
-
-# make it executable
-chmod +x /usr/local/bin/git
-
-# Add our nfs mount to fstab
-echo 'otc-mesa-ci.local:/srv/jenkins       /mnt/jenkins    nfs     defaults,comment=systemd.automount        0       0' >> /etc/fstab
-
-# Create the jenkins directory
-mkdir /mnt/jenkins
-chmod 0666 /mnt/jenkins
-
-# Write a tsocks configuration
-cat > /etc/tsocks.conf <<EOF
-local = 192.168.0.0/255.255.0.0
-local = 134.134.0.0/255.255.0.0
-local = 10.0.0.0/255.0.0.0
-server = 10.7.211.16
-server_type = 5
-server_port = 1080
-EOF
-
-# Symlink some i386 dev packages if the file doesn't already exist
-# This works around debian bugs
-for x in libEGL libGLU libgbm libGL libwayland-client libwayland-egl; do
-	if [ ! -a /usr/lib/i386-linux-gnu/${x}.so ]; then
-		if [ -a /usr/lib/i386-linux-gnu/${x}.so.1 ]; then
-			ln -s "/usr/lib/i386-linux-gnu/${x}.so.1" "/usr/lib/i386-linux-gnu/${x}.so"
-		elif [ -a /usr/lib/i386-linux-gnu/${x}.so.0 ]; then
-			ln -s "/usr/lib/i386-linux-gnu/${x}.so.0" "/usr/lib/i386-linux-gnu/${x}.so"
-		fi
-	fi
-done
-
-# Modify the ntp server to use the local mirror, not the debian mirrors
-sed -i -e 's!^server!#server!g' /etc/ntp.conf
-sed -i -e 's!#server ntp.your-provider.example!server amr.corp.intel.com!g' /etc/ntp.conf
-
-# use ntp to set the clock, force it to set the time
-# TODO: replace ntp with systemd-timesyncd
-systemctl stop ntp
-ntpd -gq
-
-# Configure the cache size for the jenkins user
-su jenkins -c 'ccache -M 10G'
-
-# Allow jenkins to reboot the machine
-echo -e "jenkins   ALL=(root:root) NOPASSWD: /sbin/reboot\n" >> /etc/sudoers.d/10_jenkins_reboot
-
-# fix logind to not turn off the display when the lid is closed
-# TODO: in later systemds this could be put in /etc/systemd/login.conf.d/lid.conf
-sed -i -e 's!^#HandleLidSwitch=.*!HandleLidSwitch=ignore!g' /etc/systemd/logind.conf
-
-# enable user namespaces, so we can unshare bind mounts in /tmp.  This
-# enables parallelization of jenkins builds.
-echo "kernel.unprivileged_userns_clone=1" > /etc/sysctl.d/50-unprivleged-userns-clone.conf

--- a/debian_installer/jenkins.cfg
+++ b/debian_installer/jenkins.cfg
@@ -84,91 +84,9 @@ d-i pkgsel/update-policy select none
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/bootdev string /dev/sda
 
-# Install additional packages, definately need some more things here.
-d-i pkgsel/include string \
-    sudo \
-    systemd \
-    build-essential \
-    python-simplejson \
-    python-lxml \
-    python-mako \
-    python-numpy \
-    gcc-multilib \
-    g++-multilib \
-    openjdk-7-jre \
-    tsocks \
-    git \
-    libtool \
-    autoconf \
-    ccache \
-    bison \
-    flex \
-    llvm \
-    cmake \
-    pkg-config \
-    python-git \
-    quilt \
-    docbook-website \
-    vim-nox \
-    avahi-daemon \
-    libdrm2 libdrm2:i386 \
-    emacs \
-    freeglut3 freeglut3:i386 \
-    gcc-4.9-base gcc-4.9-base:i386 \
-    libc6 libc6:i386 \
-    libc6-dev libc6-dev:i386 \
-    libcaca0 libcaca0:i386 \
-    libegl1-mesa libegl1-mesa:i386 \
-    libegl1-mesa-dev \
-    libelf-dev libelf-dev:i386 \
-    libexpat1-dev libexpat1-dev:i386 \
-    libffi-dev libffi-dev:i386 \
-    libffi6 libffi6:i386 \
-    libffi-dev \
-    libgbm1 libgbm1:i386 \
-    libgbm-dev \
-    libgcc1 libgcc1:i386 \
-    libgl1-mesa-dev \
-    libgl1-mesa-dri libgl1-mesa-dri:i386 \
-    libgl1-mesa-glx libgl1-mesa-glx:i386 \
-    libegl1-mesa libegl1-mesa:i386 \
-    libegl1-mesa-drivers libegl1-mesa-drivers:i386 \
-    libglapi-mesa \
-    libglu1-mesa libglu1-mesa:i386 \
-    libglu1-mesa-dev \
-    libllvm3.4 libllvm3.4:i386 \
-    libpciaccess-dev libpciaccess-dev:i386 \
-    libpciaccess0 libpciaccess0:i386 \
-    libpng12-dev \
-    libpthread-stubs0-dev \
-    libtinfo-dev libtinfo-dev:i386 \
-    libudev-dev libudev-dev:i386 \
-    libvdpau-dev libvdpau-dev:i386 \
-    libx11-dev libx11-dev:i386 \
-    libx11-xcb-dev libx11-xcb-dev:i386 \
-    libxcb-dri2-0-dev libxcb-dri2-0-dev:i386 \
-    libxcb-dri3-dev libxcb-dri3-dev:i386 \
-    libxcb-glx0-dev libxcb-glx0-dev:i386 \
-    libxcb-present-dev libxcb-present-dev:i386 \
-    libxcb-randr0-dev libxcb-randr0-dev:i386 \
-    libxcb-sync-dev libxcb-sync-dev:i386 \
-    libxcb-xfixes0-dev libxcb-xfixes0-dev:i386 \
-    libxdamage-dev libxdamage-dev:i386 \
-    libxext-dev libxext-dev:i386 \
-    libxfixes-dev libxfixes-dev:i386 \
-    libxrender1 libxrender1:i386 \
-    libxshmfence-dev libxshmfence-dev:i386 \
-    libxxf86vm-dev libxxf86vm-dev:i386 \
-    linux-libc-dev linux-libc-dev:i386 \
-    libssl-dev libssl-dev:i386 \
-    scons \
-    x11proto-dri2-dev \
-    x11proto-dri3-dev \
-    x11proto-gl-dev \
-    x11proto-present-dev \
-    xutils-dev \
-    valgrind \
-    salt-minion
+# Install the salt-minion and avahi-daemon
+# These are needed for salt to finish provisioning the system
+d-i pkgsel/include string salt-minion avahi-daemon
 
 d-i preseed/late_command string \
     cp /cdrom/finalize.sh /target/finalize.sh; in-target ./finalize.sh

--- a/debian_installer/jenkins.cfg
+++ b/debian_installer/jenkins.cfg
@@ -86,35 +86,93 @@ d-i grub-installer/bootdev string /dev/sda
 
 # Install additional packages, definately need some more things here.
 d-i pkgsel/include string \
-	sudo \
-	systemd \
-	ntp \
-	build-essential \
-	python-simplejson \
-	python-lxml \
-	python-mako \
-	python-numpy \
-	gcc-multilib \
-	g++-multilib \
-	openjdk-7-jre \
-	tsocks \
-	git \
-	libtool \
-	autoconf \
-	ccache \
-	bison \
-	flex \
-	llvm \
-	cmake \
-	pkg-config \
-	python-git \
-	quilt \
-	docbook-website \
-	vim-nox
+    sudo \
+    systemd \
+    build-essential \
+    python-simplejson \
+    python-lxml \
+    python-mako \
+    python-numpy \
+    gcc-multilib \
+    g++-multilib \
+    openjdk-7-jre \
+    tsocks \
+    git \
+    libtool \
+    autoconf \
+    ccache \
+    bison \
+    flex \
+    llvm \
+    cmake \
+    pkg-config \
+    python-git \
+    quilt \
+    docbook-website \
+    vim-nox \
+    avahi-daemon \
+    libdrm2 libdrm2:i386 \
+    emacs \
+    freeglut3 freeglut3:i386 \
+    gcc-4.9-base gcc-4.9-base:i386 \
+    libc6 libc6:i386 \
+    libc6-dev libc6-dev:i386 \
+    libcaca0 libcaca0:i386 \
+    libegl1-mesa libegl1-mesa:i386 \
+    libegl1-mesa-dev \
+    libelf-dev libelf-dev:i386 \
+    libexpat1-dev libexpat1-dev:i386 \
+    libffi-dev libffi-dev:i386 \
+    libffi6 libffi6:i386 \
+    libffi-dev \
+    libgbm1 libgbm1:i386 \
+    libgbm-dev \
+    libgcc1 libgcc1:i386 \
+    libgl1-mesa-dev \
+    libgl1-mesa-dri libgl1-mesa-dri:i386 \
+    libgl1-mesa-glx libgl1-mesa-glx:i386 \
+    libegl1-mesa libegl1-mesa:i386 \
+    libegl1-mesa-drivers libegl1-mesa-drivers:i386 \
+    libglapi-mesa \
+    libglu1-mesa libglu1-mesa:i386 \
+    libglu1-mesa-dev \
+    libllvm3.4 libllvm3.4:i386 \
+    libpciaccess-dev libpciaccess-dev:i386 \
+    libpciaccess0 libpciaccess0:i386 \
+    libpng12-dev \
+    libpthread-stubs0-dev \
+    libtinfo-dev libtinfo-dev:i386 \
+    libudev-dev libudev-dev:i386 \
+    libvdpau-dev libvdpau-dev:i386 \
+    libx11-dev libx11-dev:i386 \
+    libx11-xcb-dev libx11-xcb-dev:i386 \
+    libxcb-dri2-0-dev libxcb-dri2-0-dev:i386 \
+    libxcb-dri3-dev libxcb-dri3-dev:i386 \
+    libxcb-glx0-dev libxcb-glx0-dev:i386 \
+    libxcb-present-dev libxcb-present-dev:i386 \
+    libxcb-randr0-dev libxcb-randr0-dev:i386 \
+    libxcb-sync-dev libxcb-sync-dev:i386 \
+    libxcb-xfixes0-dev libxcb-xfixes0-dev:i386 \
+    libxdamage-dev libxdamage-dev:i386 \
+    libxext-dev libxext-dev:i386 \
+    libxfixes-dev libxfixes-dev:i386 \
+    libxrender1 libxrender1:i386 \
+    libxshmfence-dev libxshmfence-dev:i386 \
+    libxxf86vm-dev libxxf86vm-dev:i386 \
+    linux-libc-dev linux-libc-dev:i386 \
+    libssl-dev libssl-dev:i386 \
+    scons \
+    x11proto-dri2-dev \
+    x11proto-dri3-dev \
+    x11proto-gl-dev \
+    x11proto-present-dev \
+    xutils-dev \
+    valgrind \
+    salt-minion
 
 d-i preseed/late_command string \
-	cp /cdrom/finalize.sh /target/finalize.sh; in-target ./finalize.sh
-	
+    cp /cdrom/finalize.sh /target/finalize.sh; in-target ./finalize.sh
+
 # poweroff the machine when finished
 d-i finish-install/reboot_in_progress note
 d-i debian-installer/exit/poweroff boolean true

--- a/debian_installer/jenkins.cfg
+++ b/debian_installer/jenkins.cfg
@@ -86,7 +86,9 @@ d-i grub-installer/bootdev string /dev/sda
 
 # Install the salt-minion and avahi-daemon
 # These are needed for salt to finish provisioning the system
-d-i pkgsel/include string salt-minion avahi-daemon
+# XXX: Tsocks is required here because it is currently only in debian stable
+# and sid, but not testing for "reasons"
+d-i pkgsel/include string salt-minion avahi-daemon tsocks
 
 d-i preseed/late_command string \
     cp /cdrom/finalize.sh /target/finalize.sh; in-target ./finalize.sh


### PR DESCRIPTION
This removes a number of setup requirements that are now handled by the
salt-master/salt-minion, or are updates because they are no longer
required.

Basically we've moved as much functionality out of the debian installer as possible and into the salt setup.

A few unrelated changes:
- systemd is the default in debian 8.x, so don't force install it
- drop use of ntpd, use systemd-timesyncd instead. It's already
  installed and works just as well.