### PR TITLE
build_support/builders.py: Add bin for wflinfo to piglit's path

### DIFF
--- a/build_support/builders.py
+++ b/build_support/builders.py
@@ -285,6 +285,10 @@ class PiglitTester(object):
 
                 # In the event of a piglit related bug, we want the backtrace
                 "PIGLIT_DEBUG": "1",
+
+                # Set the patth to include buildroot/bin so fast skipping works
+                'PATH': '{}:{}'.format(os.path.join(self.build_root, 'bin'),
+                                       os.environ['PATH']),
         }
 
     def test(self):


### PR DESCRIPTION
This allows piglit to query wflinfo, which provides it with the ability
to use the new fast skipping mechanism.

This is needed to make the fast-skipping patches I sent out work with jenkins.