### PR TITLE
crucible-test: Fix a depthstencil test on bdw, skl

### DIFF
--- a/crucible-test/bdw.conf
+++ b/crucible-test/bdw.conf
@@ -1,6 +1,5 @@
 [expected-failures]
 func.desc.dynamic.uniform-buffer = mesa 1c605c8
-func.depthstencil.basic-depth.clear-0.5.op-greater-equal = mesa 1afe33f
 func.miptree.s8-uint.aspect-stencil.view-1d.levels02.array02.extent-1024.upload-copy-from-buffer.download-copy-to-buffer = mesa 4c5dcccfba3c9d0e5c7302aa797ad8d31f18cf52
 func.miptree.s8-uint.aspect-stencil.view-1d.levels01.array01.extent-1024.upload-copy-from-buffer.download-copy-to-buffer = mesa 4c5dcccfba3c9d0e5c7302aa797ad8d31f18cf52
 func.miptree.s8-uint.aspect-stencil.view-1d.levels02.array01.extent-1024.upload-copy-from-buffer.download-copy-to-buffer = mesa 4c5dcccfba3c9d0e5c7302aa797ad8d31f18cf52
@@ -49,4 +48,4 @@ func.compute.local-id.push-constant = crucible f2ba6fc
 func.compute.num-workgroups.indirect = crucible f2ba6fc
 func.compute.local-id.basic = crucible f2ba6fc
 func.compute.local-id.local-ids = crucible f2ba6fc
-
+func.depthstencil.basic-depth.clear-0.5.op-greater-equal = crucible d2226004c9a02b019e3b6fbe0cbad7e2f4c7c8f1

--- a/crucible-test/skl.conf
+++ b/crucible-test/skl.conf
@@ -1,6 +1,5 @@
 [expected-failures]
 func.desc.dynamic.uniform-buffer = mesa 1c605c8
-func.depthstencil.basic-depth.clear-0.5.op-greater-equal = mesa 1afe33f
 func.miptree.d32-sfloat.aspect-depth.view-1d.levels02.array01.extent-1024.upload-copy-from-buffer.download-copy-to-buffer = mesa 4c5dcccfba3c9d0e5c7302aa797ad8d31f18cf52
 func.miptree.s8-uint.aspect-stencil.view-1d.levels02.array02.extent-1024.upload-copy-from-buffer.download-copy-to-buffer = mesa 4c5dcccfba3c9d0e5c7302aa797ad8d31f18cf52
 func.miptree.d32-sfloat.aspect-depth.view-1d.levels02.array02.extent-1024.upload-copy-from-linear-image.download-copy-to-buffer = mesa 4c5dcccfba3c9d0e5c7302aa797ad8d31f18cf52
@@ -76,4 +75,4 @@ func.compute.local-id.push-constant = crucible f2ba6fc
 func.compute.num-workgroups.indirect = crucible f2ba6fc
 func.compute.local-id.basic = crucible f2ba6fc
 func.compute.local-id.local-ids = crucible f2ba6fc
-
+func.depthstencil.basic-depth.clear-0.5.op-greater-equal = crucible d2226004c9a02b019e3b6fbe0cbad7e2f4c7c8f1


### PR DESCRIPTION
It may also be fixed on other chipsets, but I didn't test them.