### PR TITLE
debian_installer: work around salt-minion not being in testing

### DIFF
--- a/debian_installer/finalize.sh
+++ b/debian_installer/finalize.sh
@@ -70,6 +70,15 @@ rm /etc/network/interfaces
 mkdir -p /boot/efi/EFI/boot/
 cp /boot/efi/EFI/debian/grubx64.efi /boot/efi/EFI/boot/bootx64.efi
 
+# Salt is not in testing ATM, only sid and stable, so install it from sid
+mkdir -p /etc/apt/sources.list.d/ || true
+cat > /etc/apt/sources.list.d/unstable.list << EOF
+deb http://linux-ftp.jf.intel.com/pub/mirrors/debian/ unstable main
+deb-src http://linux-ftp.jf.intel.com/pub/mirrors/debian/ unstable main
+EOF
+apt update
+apt install -t unstable salt-minion
+
 # Enable and disable some services
 systemctl enable systemd-networkd systemd-resolved avahi-daemon salt-minion
 systemctl disable networking

--- a/debian_installer/jenkins.cfg
+++ b/debian_installer/jenkins.cfg
@@ -87,9 +87,9 @@ d-i grub-installer/bootdev string /dev/<disk>
 
 # Install the salt-minion and avahi-daemon
 # These are needed for salt to finish provisioning the system
-# XXX: Tsocks is required here because it is currently only in debian stable
-# and sid, but not testing for "reasons"
-d-i pkgsel/include string salt-minion avahi-daemon
+# Currently the salt-minion isn't available in testing, so it's installed in
+# the finalize.sh instead
+d-i pkgsel/include string avahi-daemon
 
 d-i preseed/late_command string \
     cp /cdrom/finalize.sh /target/finalize.sh; in-target ./finalize.sh


### PR DESCRIPTION
by installing from unstable.