### PR TITLE
glcts: enable kc-cts

### DIFF
--- a/build_support/bisect_test.py
+++ b/build_support/bisect_test.py
@@ -674,7 +674,7 @@ class DeqpTest:
             self.project = "deqp-test"
         elif "KHR-GLES" in self.test_name:
             self.project = "glescts-test"
-        elif "KHR-GL" in self.test_name:
+        elif "KHR-GL" in self.test_name or "GTF-GL" in self.test_name:
             self.project = "glcts-test"
 
         hwarch = full_test_name.split(".")[-1]

--- a/build_support/deqp_builder.py
+++ b/build_support/deqp_builder.py
@@ -121,9 +121,12 @@ class DeqpTrie:
         elif "GL33" in xml_file:
             current_trie = DeqpTrie()
             self._trie["KHR-GL33"] = current_trie
-        elif "GL46" in xml_file:
+        elif "KHR-GL46" in xml_file:
             current_trie = DeqpTrie()
             self._trie["KHR-GL46"] = current_trie
+        elif "GTF-GL46" in xml_file:
+            current_trie = DeqpTrie()
+            self._trie["GTF-GL46"] = current_trie
         else:
             return
         root = et.parse(xml_file).getroot()

--- a/glcts-test/bdw.conf
+++ b/glcts-test/bdw.conf
@@ -8,6 +8,8 @@ KHR-GL46.shader_draw_parameters_tests.ShaderMultiDrawArraysParameters = glcts 72
 KHR-GL46.spirv_extensions.spirv_extensions_queries = glcts 72aa38edfac504bf285dffc7edd2d263039730d6
 
 [expected-crashes]
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.enhanced_layouts.varying_location_limit = mesa 2d87caa279ea319fa89572fb8595a46c05a615c4

--- a/glcts-test/bsw.conf
+++ b/glcts-test/bsw.conf
@@ -8,6 +8,8 @@ KHR-GL46.shader_draw_parameters_tests.ShaderMultiDrawArraysParameters = glcts 72
 KHR-GL46.spirv_extensions.spirv_extensions_queries = glcts 72aa38edfac504bf285dffc7edd2d263039730d6
 
 [expected-crashes]
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.enhanced_layouts.varying_location_limit = mesa 2d87caa279ea319fa89572fb8595a46c05a615c4

--- a/glcts-test/build.py
+++ b/glcts-test/build.py
@@ -37,6 +37,7 @@ class GLCTSList(object):
             all_tests.add_xml("KHR-GL33-cases.xml")
         else:
             all_tests.add_xml("KHR-GL46-cases.xml")
+            all_tests.add_xml("GTF-GL46-cases.xml")
         os.chdir(savedir)
         return all_tests
 

--- a/glcts-test/bxt.conf
+++ b/glcts-test/bxt.conf
@@ -8,6 +8,8 @@ KHR-GL46.shader_draw_parameters_tests.ShaderMultiDrawArraysParameters = glcts 72
 KHR-GL46.spirv_extensions.spirv_extensions_queries = glcts 72aa38edfac504bf285dffc7edd2d263039730d6
 
 [expected-crashes]
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.enhanced_layouts.varying_location_limit = mesa 2d87caa279ea319fa89572fb8595a46c05a615c4

--- a/glcts-test/byt_blacklist.txt
+++ b/glcts-test/byt_blacklist.txt
@@ -1,2 +1,3 @@
 KHR-GL46
+GTF-GL46
 

--- a/glcts-test/cfl.conf
+++ b/glcts-test/cfl.conf
@@ -8,6 +8,8 @@ KHR-GL46.shader_draw_parameters_tests.ShaderMultiDrawArraysParameters = mesa 59f
 KHR-GL46.spirv_extensions.spirv_extensions_queries = mesa 59fb59ad54d368683d5cc3b149f021452bddc05f
 
 [expected-crashes]
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.enhanced_layouts.varying_location_aliasing_with_mixed_interpolation = mesa 13652e7516a3ef75c5ae75ffa5c7f048629bf772

--- a/glcts-test/glk.conf
+++ b/glcts-test/glk.conf
@@ -8,6 +8,8 @@ KHR-GL46.shader_draw_parameters_tests.ShaderMultiDrawArraysParameters = glcts 72
 KHR-GL46.spirv_extensions.spirv_extensions_queries = glcts 72aa38edfac504bf285dffc7edd2d263039730d6
 
 [expected-crashes]
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.enhanced_layouts.varying_location_limit = mesa 2d87caa279ea319fa89572fb8595a46c05a615c4

--- a/glcts-test/hsw.conf
+++ b/glcts-test/hsw.conf
@@ -22,6 +22,8 @@ KHR-GL46.vertex_attrib_binding.basic-inputL-case1 = glcts 72aa38edfac504bf285dff
 
 [expected-crashes]
 KHR-GL46.direct_state_access.textures_compressed_subimage = glcts 72aa38edfac504bf285dffc7edd2d263039730d6
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.shading_language_420pack.binding_image_default = glcts d4f86c3ded810bca1a6bfbbe41800aee7ad515f5

--- a/glcts-test/ivb_blacklist.txt
+++ b/glcts-test/ivb_blacklist.txt
@@ -1,1 +1,2 @@
 KHR-GL46
+GTF-GL46

--- a/glcts-test/kbl.conf
+++ b/glcts-test/kbl.conf
@@ -8,9 +8,12 @@ KHR-GL46.shader_draw_parameters_tests.ShaderMultiDrawArraysParameters = glcts 72
 KHR-GL46.spirv_extensions.spirv_extensions_queries = glcts 72aa38edfac504bf285dffc7edd2d263039730d6
 
 [expected-crashes]
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.enhanced_layouts.xfb_block_stride = mesa 9d53ccccb251d21f9291abaa3a28a41d06ce8c91
 KHR-GL46.enhanced_layouts.varying_location_aliasing_with_mixed_interpolation mesa_post_17_3 c85d64cf67827e1fce81976db092c445b1d3fffd
 KHR-GL46.enhanced_layouts.varying_block_automatic_member_locations mesa_post_17_3 c85d64cf67827e1fce81976db092c445b1d3fffd
 KHR-GL46.enhanced_layouts.varying_location_aliasing_with_mixed_auxiliary_storage mesa_post_17_3 c85d64cf67827e1fce81976db092c445b1d3fffd
+

--- a/glcts-test/skl.conf
+++ b/glcts-test/skl.conf
@@ -8,9 +8,12 @@ KHR-GL46.shader_draw_parameters_tests.ShaderMultiDrawArraysParameters = glcts 72
 KHR-GL46.spirv_extensions.spirv_extensions_queries = glcts 72aa38edfac504bf285dffc7edd2d263039730d6
 
 [expected-crashes]
+GTF-GL46.gtf45 = mesa 49a612d1580b3316392273a069d20d93967126a8
+GTF-GL46.gtf46 = mesa 49a612d1580b3316392273a069d20d93967126a8
 
 [fixed-tests]
 KHR-GL46.enhanced_layouts.xfb_block_stride = mesa 9d53ccccb251d21f9291abaa3a28a41d06ce8c91
 KHR-GL46.enhanced_layouts.varying_location_aliasing_with_mixed_interpolation mesa_post_17_3 c85d64cf67827e1fce81976db092c445b1d3fffd
 KHR-GL46.enhanced_layouts.varying_block_automatic_member_locations mesa_post_17_3 c85d64cf67827e1fce81976db092c445b1d3fffd
 KHR-GL46.enhanced_layouts.varying_location_aliasing_with_mixed_auxiliary_storage mesa_post_17_3 c85d64cf67827e1fce81976db092c445b1d3fffd
+

--- a/glcts-test/snb_blacklist.txt
+++ b/glcts-test/snb_blacklist.txt
@@ -1,1 +1,2 @@
 KHR-GL46
+GTF-GL46


### PR DESCRIPTION
This enables the kc-cts (formerly known as GTF) tests for hw supporting
GL46.
Note that GTF-GL46.{gtf45,gtf46} have to be blacklisted at the
moment since these test groups are empty.