### PR TITLE
fix omx for all 3 configurations.

### DIFF
--- a/mesa/build.py
+++ b/mesa/build.py
@@ -58,14 +58,25 @@ class MesaBuilder(bs.AutoBuilder):
 
 def meson_build():
     global_opts = bs.Options()
+    pm = bs.ProjectMap()
+    sd = pm.project_source_dir(pm.current_project())
 
     options = [
         '-Dgallium-drivers=',
         '-Ddri-drivers=i965,i915',
         '-Dvulkan-drivers=intel',
         '-Dplatforms=x11,drm',
-        '-Dgallium-omx=disabled',
     ]
+    # For a few days durring the commit cyle the 'auto' option was removed from
+    # omx and it defaulted to tizonia. during that time we need this to set the
+    # -Dgallium-omx=disabled. This can be removed after we're sure we don't
+    # need to bisect across that.
+    with open(os.path.join(sd, 'meson_options.txt')) as f:
+        for l in f:
+            if 'tizonia' in l:
+                options.append('-Dgallium-omx=disabled')
+                break
+
     if global_opts.config != 'debug':
         options.extend(['-Dbuildtype=release', '-Db_ndebug=true'])
     b = bs.builders.MesonBuilder(extra_definitions=options, install=True)

--- a/meson-buildtest/build.py
+++ b/meson-buildtest/build.py
@@ -19,7 +19,6 @@ def main():
     options = [
         '-Dbuild-tests=true',
         '-Dgallium-drivers=r300,r600,radeonsi,nouveau,swrast,swr,freedreno,vc4,pl111,etnaviv,imx,svga,virgl',
-        '-Dgallium-omx=bellagio',
         '-Dgallium-vdpau=true',
         '-Dgallium-xvmc=true',
         '-Dgallium-xa=true',
@@ -27,6 +26,16 @@ def main():
         '-Dgallium-nine=true',
         '-Dgallium-opencl=standalone',
     ]
+
+    # the knob for omx changed durring the 18.1 cycle, if tizonia support is
+    # present we need to use bellagio, otherwise we need true.
+    with open(os.path.join(sd, 'meson_options.txt')) as f:
+        for l in f:
+            if 'tizonia' in l:
+                options.append('-Dgallium-omx=bellagio')
+                break
+        else:
+            options.append('-Dgallium-omx=true')
     if global_opts.config != 'debug':
         options.extend(['-Dbuildtype=release', '-Db_ndebug=true'])
     b = bs.builders.MesonBuilder(extra_definitions=options, install=False)


### PR DESCRIPTION
Because omx got busted hard.

This should fix both mesa and the meson-buildtest to build during all three states, [auto, true, false], [disabled, tizonia, bellagio], and [auto, disabled, tizonia, bellagio].

I'm testing on current master now.