### PR TITLE
build_spec: Split chadv into gl and vk branches

### DIFF
--- a/build_specification.xml
+++ b/build_specification.xml
@@ -822,8 +822,12 @@
       <mesa branch="internal/internal"/>
     </branch>
 
-    <branch name="chadv" project="test-single-arch-vulkan">
-      <mesa branch="chadv/jenkins"/>
+    <branch name="chadv_gl" project="test-single-arch">
+      <mesa branch="chadv/intel-ci-gl"/>
+    </branch>
+
+    <branch name="chadv_vk" project="test-single-arch-vulkan">
+      <mesa branch="chadv/intel-ci-vk"/>
     </branch>
 
     <branch name="hakzsam" project="test-single-arch-vulkan">


### PR DESCRIPTION
I want to test Fritz's patch that affects OpenGL, not Vulkan. But Jenkins today only runs Vulkan on my branch.